### PR TITLE
stcompact: Ack all pending requests on node close

### DIFF
--- a/.vim/settings.json
+++ b/.vim/settings.json
@@ -1,7 +1,0 @@
-{
-    "rust": {
-        "wait_to_build": 500,
-        "clippy_preference": "on",
-        "cfg_test": true
-    }
-}

--- a/components/stcompact/src/compact_node/handle_user.rs
+++ b/components/stcompact/src/compact_node/handle_user.rs
@@ -39,6 +39,11 @@ where
         inner: user_to_compact,
     } = from_user;
 
+    // Keep the request id:
+    server_state
+        .pending_user_requests
+        .insert(user_request_id.clone());
+
     match user_to_compact {
         // ==================[Configuration]==============================
         UserToCompact::AddRelay(named_relay_address) => {

--- a/components/stcompact/src/compact_node/types.rs
+++ b/components/stcompact/src/compact_node/types.rs
@@ -1,5 +1,8 @@
+use std::collections::HashSet;
+
 use common::conn::ConnPair;
 
+use app::common::Uid;
 use app::conn::AppServerToApp;
 use database::DatabaseClient;
 
@@ -29,6 +32,9 @@ pub struct CompactServerState {
     node_report: app::report::NodeReport,
     compact_state: CompactState,
     database_client: DatabaseClient<CompactState>,
+    /// Ids of requests that were initiated directly by the user,
+    /// and were not acked yet.
+    pub pending_user_requests: HashSet<Uid>,
 }
 
 impl CompactServerState {
@@ -41,6 +47,7 @@ impl CompactServerState {
             node_report,
             compact_state,
             database_client,
+            pending_user_requests: HashSet::new(),
         }
     }
 

--- a/components/stcompact/src/server_loop.rs
+++ b/components/stcompact/src/server_loop.rs
@@ -114,7 +114,7 @@ impl OpenNode {
         }
 
         // Add pending request:
-        self.pending_requests.insert(dbg!(request_id));
+        self.pending_requests.insert(request_id);
 
         true
     }
@@ -1343,7 +1343,7 @@ where
                 match compact_to_user_ack {
                     CompactToUserAck::Ack(request_id) => {
                         if let Some(open_node) = server_state.open_nodes.get_mut(&node_id) {
-                            let res = open_node.pending_requests.remove(dbg!(&request_id));
+                            let res = open_node.pending_requests.remove(&request_id);
                             // Make sure that we had this `request_id`:
                             assert!(res);
                         } else {


### PR DESCRIPTION
- compact_node: Fix leak of internal `request_id`-s.
- stcompact: Ack all pending requests when a node is closed (Avoids mobile app freeze in infinite transition)