### PR TITLE
Fix possible timer deadlock

### DIFF
--- a/components/net/src/tcp_connector.rs
+++ b/components/net/src/tcp_connector.rs
@@ -33,6 +33,7 @@ where
 
     fn transform(&mut self, net_address: Self::Input) -> BoxFuture<'_, Self::Output> {
         Box::pin(async move {
+            info!("TcpConnector: Connecting to {:?}", net_address.as_str());
             let tcp_stream = TcpStream::connect(net_address.as_str()).await.ok()?;
 
             Some(tcp_stream_to_conn_pair(

--- a/components/net/src/tcp_listener.rs
+++ b/components/net/src/tcp_listener.rs
@@ -52,6 +52,10 @@ where
             let mut incoming_conns = listener.incoming();
 
             while let Some(Ok(tcp_stream)) = incoming_conns.next().await {
+                info!(
+                    "TcpListener: Incoming connection from: {:?}",
+                    tcp_stream.peer_addr(),
+                );
                 let conn_pair =
                     tcp_stream_to_conn_pair(tcp_stream, c_max_frame_length, &mut c_spawner);
                 if let Err(e) = conn_receiver_sender.send(conn_pair).await {

--- a/components/timer/src/timer.rs
+++ b/components/timer/src/timer.rs
@@ -103,7 +103,11 @@ enum TimerEvent {
     RequestsDone,
 }
 
-const TIMER_TICK_BUFFER: usize = 16;
+// TODO: Possibly give to timer_loop as an argument?
+/// Size of queue for pending ticks for a single client.
+/// After `TICK_QUEUE_LEN` ticks, the timer will not be able to queue more ticks to a nonresponsive
+/// client.
+const TICK_QUEUE_LEN: usize = 8;
 
 async fn timer_loop<M>(
     incoming: M,
@@ -144,7 +148,7 @@ where
                 }
             }
             TimerEvent::Request(timer_request) => {
-                let (tick_sender, tick_receiver) = mpsc::channel(TIMER_TICK_BUFFER);
+                let (tick_sender, tick_receiver) = mpsc::channel(TICK_QUEUE_LEN);
                 tick_senders.push(tick_sender);
                 let _ = timer_request.response_sender.send(tick_receiver);
             }

--- a/components/timer/src/timer.rs
+++ b/components/timer/src/timer.rs
@@ -130,8 +130,16 @@ where
                 let mut temp_tick_senders = Vec::new();
                 temp_tick_senders.append(&mut tick_senders);
                 for mut tick_sender in temp_tick_senders {
-                    if let Ok(()) = tick_sender.try_send(TimerTick) {
-                        tick_senders.push(tick_sender);
+                    match tick_sender.try_send(TimerTick) {
+                        Ok(()) => tick_senders.push(tick_sender),
+                        Err(e) => {
+                            // In case of error, we disconnect client
+                            if !e.is_disconnected() {
+                                // Error trying to send a tick to client.
+                                // Client might be too busy?
+                                error!("timer_loop(): try_send() error: {:?}", e);
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
- timer: Increased queue size for timer clients
- timer: Dropping a client if not ready for a timer tick (Possibly reconsider this design in the future?)
- Fixed tests according to new timer design