### PR TITLE
Asynchronous listener trait

### DIFF
--- a/components/common/src/conn.rs
+++ b/components/common/src/conn.rs
@@ -100,18 +100,27 @@ pub trait Connector {
 }
 */
 
+/// A client for a spanwed listener
+pub struct ListenClient<CF, CN> {
+    /// A channel for sending configurations
+    pub config_sender: mpsc::Sender<CF>,
+    /// A receiver for incoming connections
+    pub conn_receiver: mpsc::Receiver<CN>,
+}
+
 /// Listen to connections from remote entities
 pub trait Listener {
-    type Connection;
+    /// Configuration message
     type Config;
-    type Arg;
+    /// A new incoming connection
+    type Conn;
+    /// Listen error
+    type Error;
 
-    // TODO: Possibly change this to be async, as binding to the given address is an async event
-    // too.
+    /// Start listening for new connections
     fn listen(
         self,
-        arg: Self::Arg,
-    ) -> (mpsc::Sender<Self::Config>, mpsc::Receiver<Self::Connection>);
+    ) -> BoxFuture<'static, Result<ListenClient<Self::Config, Self::Conn>, Self::Error>>;
 }
 
 /// Apply a futuristic function over an input. Returns a boxed future that resolves

--- a/components/net/src/tcp_listener.rs
+++ b/components/net/src/tcp_listener.rs
@@ -7,64 +7,74 @@ use futures::task::{Spawn, SpawnExt};
 use futures::{SinkExt, StreamExt};
 
 use crate::utils::tcp_stream_to_conn_pair;
-use common::conn::{ConnPairVec, Listener};
+use common::conn::{BoxFuture, ConnPairVec, ListenClient, Listener};
 
 /// Listen for incoming TCP connections
 pub struct TcpListener<S> {
     max_frame_length: usize,
+    socket_addr: SocketAddr,
     spawner: S,
 }
 
 impl<S> TcpListener<S> {
-    pub fn new(max_frame_length: usize, spawner: S) -> Self {
+    pub fn new(max_frame_length: usize, socket_addr: SocketAddr, spawner: S) -> Self {
         TcpListener {
             max_frame_length,
+            socket_addr,
             spawner,
         }
     }
 }
 
+#[derive(Debug)]
+pub struct TcpListenerError;
+
 impl<S> Listener for TcpListener<S>
 where
     S: Spawn + Send + Clone + 'static,
 {
-    type Connection = ConnPairVec;
+    type Conn = ConnPairVec;
     type Config = ();
-    type Arg = SocketAddr;
+    type Error = TcpListenerError;
 
     fn listen(
         self,
-        socket_addr: Self::Arg,
-    ) -> (mpsc::Sender<Self::Config>, mpsc::Receiver<Self::Connection>) {
+    ) -> BoxFuture<'static, Result<ListenClient<Self::Config, Self::Conn>, Self::Error>> {
         let (config_sender, _config_sender_receiver) = mpsc::channel(0);
         let (mut conn_receiver_sender, conn_receiver) = mpsc::channel(0);
 
-        let mut c_spawner = self.spawner.clone();
-        let c_max_frame_length = self.max_frame_length;
-        let _ = self.spawner.spawn(async move {
-            let listener = match AsyncStdTcpListener::bind(&socket_addr).await {
+        Box::pin(async move {
+            let mut c_spawner = self.spawner.clone();
+            let c_max_frame_length = self.max_frame_length;
+            let listener = match AsyncStdTcpListener::bind(&self.socket_addr).await {
                 Ok(listener) => listener,
                 Err(e) => {
-                    warn!("Failed listening on {:?}: {:?}", socket_addr, e);
-                    return;
+                    warn!("Failed listening on {:?}: {:?}", self.socket_addr, e);
+                    return Err(TcpListenerError);
                 }
             };
-            let mut incoming_conns = listener.incoming();
 
-            while let Some(Ok(tcp_stream)) = incoming_conns.next().await {
-                info!(
-                    "TcpListener: Incoming connection from: {:?}",
-                    tcp_stream.peer_addr(),
-                );
-                let conn_pair =
-                    tcp_stream_to_conn_pair(tcp_stream, c_max_frame_length, &mut c_spawner);
-                if let Err(e) = conn_receiver_sender.send(conn_pair).await {
-                    warn!("TcpListener::listen(): Send error: {:?}", e);
-                    return;
+            let _ = self.spawner.spawn(async move {
+                let mut incoming_conns = listener.incoming();
+
+                while let Some(Ok(tcp_stream)) = incoming_conns.next().await {
+                    info!(
+                        "TcpListener: Incoming connection from: {:?}",
+                        tcp_stream.peer_addr(),
+                    );
+                    let conn_pair =
+                        tcp_stream_to_conn_pair(tcp_stream, c_max_frame_length, &mut c_spawner);
+                    if let Err(e) = conn_receiver_sender.send(conn_pair).await {
+                        warn!("TcpListener::listen(): Send error: {:?}", e);
+                        return;
+                    }
                 }
-            }
-        });
+            });
 
-        (config_sender, conn_receiver)
+            Ok(ListenClient {
+                config_sender,
+                conn_receiver,
+            })
+        })
     }
 }

--- a/components/relay/src/client/client_listener.rs
+++ b/components/relay/src/client/client_listener.rs
@@ -319,14 +319,10 @@ where
     type Conn = (PublicKey, ConnPairVec);
     type Config = AccessControlOpPk;
     type Error = ClientListenerError;
-    // type Arg = (A, AccessControlPk);
 
     fn listen(
         mut self,
-        // arg: (A, AccessControlPk),
     ) -> BoxFuture<'static, Result<ListenClient<Self::Config, Self::Conn>, Self::Error>> {
-        // let (relay_address, mut access_control) = arg;
-
         let c_spawner = self.spawner.clone();
         let (access_control_sender, mut access_control_receiver) = mpsc::channel(0);
         let (connections_sender, connections_receiver) = mpsc::channel(0);


### PR DESCRIPTION
Currently the `Listener` trait has a synchronous `listen()` method.
In some of our tests we start a listener, and then want to connect to the listener. Unfortunately, there is no way to know how long should we wait before we attempt to connect. 

By having an asynchronous `listen()` we will be able to continue execution only after binding and listening has begun. This should eliminate multiple asynchronous `sleep()` invocations in our tests code.